### PR TITLE
Update set_proxy.sh

### DIFF
--- a/set_proxy.sh
+++ b/set_proxy.sh
@@ -4,38 +4,38 @@
 # Contributions from TheMousePotato and Ayushk4
 
 if [ `id -u` -ne 0 ]
-   then echo "Error: needs to be run as sudo!!"
-   exit 1
+  then echo "Error: needs to be run as sudo!!"
+  exit 1
 fi
 
-for i in "$@"
-do
-case $i in
-    --unset)
-    gsettings set org.gnome.system.proxy mode none
-    truncate -s 0 /etc/profile.d/proxy.sh
-    sed -i.bak "/Acquire::/d" /etc/apt/apt.conf
-    sed -i.bak "/Acquire::/,+10d" /etc/apt/apt.conf.d/70debconf
-    sed -i "/proxy/d" /etc/environment
-    sed -i "/PROXY/d" /etc/environment
-    if hash git 2>/dev/null; then
-	git config --global --unset http.proxy
-	git config --global --unset https.proxy
-    fi
-    exit 0
-    ;;
-    *)
-    echo "Invalid option"
-    exit 0
-    ;;
-esac
-done
+exit_with_usage ()
+{
+echo "setproxy: invalid option"
+echo "Usage: ./set_proxy.sh -h [PROXY HOST] -p [PROXY PORT]"
+echo "Try './set_proxy.sh --help' for more information."
+# Help to be added later when script functions increases
+exit 1
+}
 
-echo "Proxy Host:"; read PROXY_HOST
-echo "Proxy Port:"; read PROXY_PORT
-
+reset_proxy ()
+{
+echo "resetting proxy.."
+gsettings set org.gnome.system.proxy mode none
+truncate -s 0 /etc/profile.d/proxy.sh
+sed -i.bak "/Acquire::/d" /etc/apt/apt.conf
+sed -i.bak "/Acquire::/,+10d" /etc/apt/apt.conf.d/70debconf
+sed -i "/proxy/d" /etc/environment
+sed -i "/PROXY/d" /etc/environment
+if hash git 2>/dev/null; then
+  git config --global --unset http.proxy
+  git config --global --unset https.proxy
+fi
+echo "done"
+}
 
 # setting system wide proxy
+set_systemwide_proxy () 
+{
 gsettings set org.gnome.system.proxy mode 'manual'
 gsettings set org.gnome.system.proxy.http host "$PROXY_HOST"
 gsettings set org.gnome.system.proxy.http port "$PROXY_PORT"
@@ -44,17 +44,26 @@ gsettings set org.gnome.system.proxy.https port "$PROXY_PORT"
 gsettings set org.gnome.system.proxy.ftp host "$PROXY_HOST"
 gsettings set org.gnome.system.proxy.ftp port "$PROXY_PORT"
 gsettings set org.gnome.system.proxy ignore-hosts "['localhost', '127.0.0.0/8', '127.0.0.1/8', '::1', '10.*.*.*']"
+echo "systemwide proxy set"
+}
 
-# setting apt proxy
-## in apt.conf
+# setting APT-conf proxy
+
+## in /etc/apt/conf **deprecated**
+set_apt_proxy_old ()
+{
 sed -i.bak '/http[s]::proxy/Id' /etc/apt/apt.conf
 tee -a /etc/apt/apt.conf <<EOF
 Acquire::http::proxy "http://${PROXY_HOST}:${PROXY_PORT}";
 Acquire::https::proxy "http://${PROXY_HOST}:${PROXY_PORT}";
 Acquire::ftp::proxy "http://${PROXY_HOST}:${PROXY_PORT}";
 EOF
+echo "APT proxy set"
+}
 
-## in apt.conf.d/70debconf
+## in /etc/apt/apt.conf.d/70debconf
+set_apt_proxy ()
+{
 sed -i.bak '/http[s]::proxy/Id' /etc/apt/apt.conf.d/70debconf
 tee -a /etc/apt/apt.conf.d/70debconf <<EOF
 Acquire::http::proxy "http://${PROXY_HOST}:${PROXY_PORT}";
@@ -69,9 +78,12 @@ Acquire::ftp
    }
  }
 EOF
-
+echo "APT proxy set"
+}
 
 # setting environment proxy
+set_environment_proxy ()
+{
 sed -i.bak '/http[s]_proxy/Id' /etc/environment
 tee -a /etc/environment <<EOF
 http_proxy="http://${PROXY_HOST}:${PROXY_PORT}"
@@ -82,8 +94,12 @@ HTTPS_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
 FTP_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
 no_proxy=localhost,127.0.0.0/8,::1,10.0.0.0/8,127.0.0.1/8
 EOF
+echo "Environment proxy set"
+}
 
-# proxy for profile
+# setting bash profile proxy 
+set_profile_proxy ()
+{
 touch /etc/profile.d/proxy.sh
 tee -a /etc/profile.d/proxy.sh <<EOF
 export http_proxy="http://${PROXY_HOST}:${PROXY_PORT}"
@@ -91,10 +107,65 @@ export https_proxy="http://${PROXY_HOST}:${PROXY_PORT}"
 export HTTP_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
 export HTTPS_PROXY="http://${PROXY_HOST}:${PROXY_PORT}"
 EOF
+echo "Profile proxy set"
+}
 
 # application specific proxy
-# git
+
+# setting Git proxy
+set_git_proxy ()
+{
 if hash git 2>/dev/null; then
-	git config --global http.proxy "http://${PROXY_HOST}:${PROXY_PORT}"
-	git config --global https.proxy "http://${PROXY_HOST}:${PROXY_PORT}"
+  git config --global http.proxy "http://${PROXY_HOST}:${PROXY_PORT}"
+  git config --global https.proxy "http://${PROXY_HOST}:${PROXY_PORT}"
 fi
+echo "Git proxy set"
+}
+
+if [ "$#" -eq 1 ]; then
+  case $1 in    
+    -u| --unset)    
+      reset_proxy
+      exit 0
+      ;;
+    *)          
+      exit_with_usage 
+      ;;
+  esac
+fi
+
+if [ "$#" -eq 4 ]; then
+  while [ "$1" != "" ]; do
+    case $1 in
+      -h| --host)
+        shift
+        PROXY_HOST=$1
+        echo $PROXY_HOST
+        shift
+        case $1 in
+          -p| --port)
+            shift
+            PROXY_PORT=$1
+            echo $PROXY_PORT
+            shift
+            ;;
+          *) 
+            exit_with_usage 
+            ;;
+        esac
+        ;;
+      *) 
+        exit_with_usage 
+        ;;
+    esac
+  done
+  else
+    exit_with_usage
+fi
+
+set_systemwide_proxy
+set_environment_proxy
+set_apt_proxy_old
+set_apt_proxy
+set_profile_proxy
+set_git_proxy


### PR DESCRIPTION
Added arguments for hostname and port. Refractored code into functions.

I have added arguments in the script so that user enters the hostname and port while executing the command. I used _shift_ command to shift through the arguments. The following is the part of code which I have added:

`if [ "$#" -eq 4 ]; then
  while [ "$1" != "" ]; do
    case $1 in
      -h| --host)
        shift
        PROXY_HOST=$1
        echo $PROXY_HOST
        shift
        case $1 in
          -p| --port)
            shift
            PROXY_PORT=$1
            echo $PROXY_PORT
            shift
            ;;
          *) 
            exit_with_usage 
            ;;
        esac
        ;;
      *) 
        exit_with_usage 
        ;;
    esac
  done
  else
    exit_with_usage
fi`

You can execute the script by `sudo ./set_proxy.sh -h [host ip] -p [port no.]`

In rest of the code I have done modifications only. Refactored the code into functions such as enviroment_set_proxy, exit_with_usage, reset_proxy etc.